### PR TITLE
Fix env variable in docker-compose.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ services:
     image: bitnami/jasperreports:latest
     environment:
       - MARIADB_HOST=mariadb
-      - MARIADB_PORT=3306
+      - MARIADB_PORT_NUMBER=3306
       - JASPERREPORTS_DATABASE_USER=bn_jasperreports
       - JASPERREPORTS_DATABASE_NAME=bitnami_jasperreports
       - ALLOW_EMPTY_PASSWORD=yes


### PR DESCRIPTION
**Description of the change**

The example docker-compose.yml in the README.md references a MARIADB_PORT env variable which is actually MARIADB_PORT_NUMBER. Just fixing a typo here.
