### PR TITLE
fixing entrypoint to provide jasper specific config under /bitnami/jasperreports-mounted-conf

### DIFF
--- a/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
@@ -22,12 +22,10 @@ if [[ "$1" = "/opt/bitnami/scripts/tomcat/run.sh" ]]; then
     TOMCAT_ENABLE_AUTH="${TOMCAT_ENABLE_AUTH:-no}" /opt/bitnami/scripts/tomcat/setup.sh
     /opt/bitnami/scripts/jasperreports/setup.sh
     /post-init.sh
-     if [ -d "/bitnami/jasperreports/mounted-conf" ]; then
-        if ! [ -z "$(ls -A /bitnami/jasperreports-mounted-conf/)" ]; then
-            info "** User provided config detected **"
-            info "** Copy and overwrite Jasper config located into config folder and replace into WEB-INF Jasper **"
-            cp -r -L /bitnami/jasperreports-mounted-conf/* /opt/bitnami/jasperreports/WEB-INF/
-        fi
+     if ! is_dir_empty "/bitnami/jasperreports/mounted-conf"; then
+        info "** User provided config detected **"
+        info "** Copy and overwrite Jasper config located into config folder and replace into WEB-INF Jasper **"
+        cp -r -L /bitnami/jasperreports-mounted-conf/* /opt/bitnami/jasperreports/WEB-INF/
     fi
     info "** JasperReports setup finished! **"
 fi

--- a/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
@@ -22,7 +22,7 @@ if [[ "$1" = "/opt/bitnami/scripts/tomcat/run.sh" ]]; then
     TOMCAT_ENABLE_AUTH="${TOMCAT_ENABLE_AUTH:-no}" /opt/bitnami/scripts/tomcat/setup.sh
     /opt/bitnami/scripts/jasperreports/setup.sh
     /post-init.sh
-     if ! is_dir_empty "/bitnami/jasperreports/mounted-conf"; then
+     if ! is_dir_empty "/bitnami/jasperreports-mounted-conf"; then
         info "** User provided config detected **"
         info "** Copy and overwrite Jasper config located into config folder and replace into WEB-INF Jasper **"
         cp -r -L /bitnami/jasperreports-mounted-conf/* /opt/bitnami/jasperreports/WEB-INF/

--- a/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
@@ -22,6 +22,13 @@ if [[ "$1" = "/opt/bitnami/scripts/tomcat/run.sh" ]]; then
     TOMCAT_ENABLE_AUTH="${TOMCAT_ENABLE_AUTH:-no}" /opt/bitnami/scripts/tomcat/setup.sh
     /opt/bitnami/scripts/jasperreports/setup.sh
     /post-init.sh
+     if [ -d "/etc/opt/bitnami/jasperreports/config" ]; then
+        if ! [ -z "$(ls -A /etc/opt/bitnami/jasperreports/config/)" ]; then
+            info "** User provided config detected **"
+            info "** Copy and overwrite Jasper config located into config folder and replace into WEB-INF Jasper **"
+            cp -r /etc/opt/bitnami/jasperreports/config/* /opt/bitnami/jasperreports/WEB-INF/
+        fi
+    fi
     info "** JasperReports setup finished! **"
 fi
 

--- a/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports/entrypoint.sh
@@ -22,11 +22,11 @@ if [[ "$1" = "/opt/bitnami/scripts/tomcat/run.sh" ]]; then
     TOMCAT_ENABLE_AUTH="${TOMCAT_ENABLE_AUTH:-no}" /opt/bitnami/scripts/tomcat/setup.sh
     /opt/bitnami/scripts/jasperreports/setup.sh
     /post-init.sh
-     if [ -d "/etc/opt/bitnami/jasperreports/config" ]; then
-        if ! [ -z "$(ls -A /etc/opt/bitnami/jasperreports/config/)" ]; then
+     if [ -d "/bitnami/jasperreports/mounted-conf" ]; then
+        if ! [ -z "$(ls -A /bitnami/jasperreports-mounted-conf/)" ]; then
             info "** User provided config detected **"
             info "** Copy and overwrite Jasper config located into config folder and replace into WEB-INF Jasper **"
-            cp -r /etc/opt/bitnami/jasperreports/config/* /opt/bitnami/jasperreports/WEB-INF/
+            cp -r -L /bitnami/jasperreports-mounted-conf/* /opt/bitnami/jasperreports/WEB-INF/
         fi
     fi
     info "** JasperReports setup finished! **"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ $ docker-compose up -d
       - '80:8080'
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
-+     - ${PWD}/config:/etc/opt/bitnami/jasperreports/config
++     - ${PWD}/config:/bitnami/jasperreports-mounted-conf
     depends_on:
       - mariadb
     environment:

--- a/README.md
+++ b/README.md
@@ -82,26 +82,15 @@ $ docker-compose up -d
 
 ### Provide jasper specific file config
 
-```docker
-version: '2'
-services:
-  mariadb:
-    image: docker.io/bitnami/mariadb:10.3
-    volumes:
-      - 'mariadb_data:/bitnami/mariadb'
-    environment:
-      # ALLOW_EMPTY_PASSWORD is recommended only for development.
-      - ALLOW_EMPTY_PASSWORD=yes
-      - MARIADB_USER=bn_jasperreports
-      - MARIADB_DATABASE=bitnami_jasperreports
+```diff
+  ...
   jasperreports:
     image: docker.io/bitnami/jasperreports:7
     ports:
       - '80:8080'
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
-      # Add user provided config to change jasper specific config
-      - ${PWD}/config:/etc/opt/bitnami/jasperreports/config
++     - ${PWD}/config:/etc/opt/bitnami/jasperreports/config
     depends_on:
       - mariadb
     environment:
@@ -111,11 +100,6 @@ services:
       - JASPERREPORTS_DATABASE_PORT_NUMBER=3306
       - JASPERREPORTS_DATABASE_USER=bn_jasperreports
       - JASPERREPORTS_DATABASE_NAME=bitnami_jasperreports
-volumes:
-  mariadb_data:
-    driver: local
-  jasperreports_data:
-    driver: local
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ $ docker-compose up -d
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
 # The line below allows you to provide your own JasperReports configuration files, to be copied to WEB-INF
-# - "./config:/opt/bitnami/jasperreports/mounted-conf"
+# - "./config:/bitnami/jasperreports-mounted-conf"
     depends_on:
       - mariadb
     environment:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ $ docker-compose up -d
       - '80:8080'
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
-+     - ${PWD}/config:/bitnami/jasperreports-mounted-conf
+#     if you want to provide your own jasper config, add the line below
+#     - ${PWD}/config:/bitnami/jasperreports-mounted-conf
     depends_on:
       - mariadb
     environment:

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ $ docker-compose up -d
       - '80:8080'
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
-#     if you want to provide your own jasper config, add the line below
-#     - ${PWD}/config:/bitnami/jasperreports-mounted-conf
+# The line below allows you to provide your own JasperReports configuration files, to be copied to WEB-INF
+# - "./config:/opt/bitnami/jasperreports/mounted-conf"
     depends_on:
       - mariadb
     environment:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,45 @@ $ curl -sSL https://raw.githubusercontent.com/bitnami/bitnami-docker-jasperrepor
 $ docker-compose up -d
 ```
 
+### Provide jasper specific file config
+
+```docker
+version: '2'
+services:
+  mariadb:
+    image: docker.io/bitnami/mariadb:10.3
+    volumes:
+      - 'mariadb_data:/bitnami/mariadb'
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+      - MARIADB_USER=bn_jasperreports
+      - MARIADB_DATABASE=bitnami_jasperreports
+  jasperreports:
+    image: docker.io/bitnami/jasperreports:7
+    ports:
+      - '80:8080'
+    volumes:
+      - 'jasperreports_data:/bitnami/jasperreports'
+      # Add user provided config to change jasper specific config
+      - ${PWD}/config:/etc/opt/bitnami/jasperreports/config
+    depends_on:
+      - mariadb
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+      - JASPERREPORTS_DATABASE_HOST=mariadb
+      - JASPERREPORTS_DATABASE_PORT_NUMBER=3306
+      - JASPERREPORTS_DATABASE_USER=bn_jasperreports
+      - JASPERREPORTS_DATABASE_NAME=bitnami_jasperreports
+volumes:
+  mariadb_data:
+    driver: local
+  jasperreports_data:
+    driver: local
+
+```
+
 ### Using the Docker Command Line
 
 If you want to run the application manually instead of using `docker-compose`, these are the basic steps you need to run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       - '80:8080'
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
+      # Add user provided config to change jasper specific config
+      # - ${PWD}/config:/etc/opt/bitnami/jasperreports/config
     depends_on:
       - mariadb
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       - '80:8080'
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
-      # Add user provided config to change jasper specific config
-      - ${PWD}/config:/bitnami/jasperreports-mounted-conf
     depends_on:
       - mariadb
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - 'jasperreports_data:/bitnami/jasperreports'
       # Add user provided config to change jasper specific config
-      # - ${PWD}/config:/etc/opt/bitnami/jasperreports/config
+      - ${PWD}/config:/bitnami/jasperreports-mounted-conf
     depends_on:
       - mariadb
     environment:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

I'm trying to fixing this issue https://github.com/bitnami/bitnami-docker-jasperreports/issues/68 with minimal effort as i can, i added some code to entrypoint to read /etc/opt/bitnami/jasperreports/config/ which is should be added by the user when they need to add jasper specific config file like editing jasperserver-servlet.xml etc.

**Benefits**

User now can add their specific config

**Possible drawbacks**

none

**Applicable issues**

- Fixes https://github.com/bitnami/bitnami-docker-jasperreports/issues/68

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
