### PR TITLE
ROOT URL setting

### DIFF
--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -18,6 +18,8 @@ RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "git" "2.34.1-1" 
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "render-template" "1.0.1-5" --checksum 9e312b4a7e16a55d08e67c4fd69c91000e4dcc4af149d59915c49375b83852af
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "jasperreports" "7.8.1-2" --checksum 1323832c7470e3b7ca151857952a0c8ffba2d4a10d2e2c44aec7af8191e794f7
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.14.0-1" --checksum 16f1a317859b06ae82e816b30f98f28b4707d18fe6cc3881bff535192a7715dc
+RUN apt-get update && apt-get upgrade -y && \
+    rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 
 COPY rootfs /
@@ -26,7 +28,7 @@ RUN /opt/bitnami/scripts/jasperreports/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/mysql-client/postunpack.sh
 ENV BITNAMI_APP_NAME="jasperreports" \
-    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r57" \
+    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r58" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/tomcat/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:/opt/bitnami/common/bin:$PATH"
 

--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -28,7 +28,7 @@ RUN /opt/bitnami/scripts/jasperreports/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/mysql-client/postunpack.sh
 ENV BITNAMI_APP_NAME="jasperreports" \
-    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r58" \
+    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r59" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/tomcat/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:/opt/bitnami/common/bin:$PATH"
 

--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -26,7 +26,7 @@ RUN /opt/bitnami/scripts/jasperreports/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/mysql-client/postunpack.sh
 ENV BITNAMI_APP_NAME="jasperreports" \
-    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r64" \
+    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r67" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/tomcat/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:/opt/bitnami/common/bin:$PATH"
 

--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -18,8 +18,6 @@ RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "git" "2.34.1-1" 
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "render-template" "1.0.1-5" --checksum 9e312b4a7e16a55d08e67c4fd69c91000e4dcc4af149d59915c49375b83852af
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "jasperreports" "7.8.1-2" --checksum 1323832c7470e3b7ca151857952a0c8ffba2d4a10d2e2c44aec7af8191e794f7
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.14.0-1" --checksum 16f1a317859b06ae82e816b30f98f28b4707d18fe6cc3881bff535192a7715dc
-RUN apt-get update && apt-get upgrade -y && \
-    rm -r /var/lib/apt/lists /var/cache/apt/archives
 RUN chmod g+rwX /opt/bitnami
 
 COPY rootfs /

--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -26,7 +26,7 @@ RUN /opt/bitnami/scripts/jasperreports/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/mysql-client/postunpack.sh
 ENV BITNAMI_APP_NAME="jasperreports" \
-    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r62" \
+    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r64" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/tomcat/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:/opt/bitnami/common/bin:$PATH"
 

--- a/7/debian-10/Dockerfile
+++ b/7/debian-10/Dockerfile
@@ -26,7 +26,7 @@ RUN /opt/bitnami/scripts/jasperreports/postunpack.sh
 RUN /opt/bitnami/scripts/java/postunpack.sh
 RUN /opt/bitnami/scripts/mysql-client/postunpack.sh
 ENV BITNAMI_APP_NAME="jasperreports" \
-    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r59" \
+    BITNAMI_IMAGE_VERSION="7.8.1-debian-10-r62" \
     JAVA_HOME="/opt/bitnami/java" \
     PATH="/opt/bitnami/java/bin:/opt/bitnami/tomcat/bin:/opt/bitnami/mysql/bin:/opt/bitnami/git/bin:/opt/bitnami/common/bin:$PATH"
 

--- a/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports-env.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports-env.sh
@@ -21,7 +21,7 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
 jasperreports_env_vars=(
-    JASPERREPORTS_ROOT_URL
+    JASPERREPORTS_USE_ROOT_URL
     JASPERREPORTS_DATA_TO_PERSIST
     JASPERREPORTS_HOST
     JASPERREPORTS_SKIP_BOOTSTRAP
@@ -115,5 +115,5 @@ JASPERREPORTS_DATABASE_PASSWORD="${JASPERREPORTS_DATABASE_PASSWORD:-"${MARIADB_D
 export JASPERREPORTS_DATABASE_PASSWORD="${JASPERREPORTS_DATABASE_PASSWORD:-}" # only used during the first initialization
 
 # Custom environment variables may be defined below
-export JASPERREPORTS_ROOT_URL="${JASPERREPORTS_ROOT_URL:-false}" # only used during the first initialization
+export JASPERREPORTS_USE_ROOT_URL="${JASPERREPORTS_USE_ROOT_URL:-false}" # only used during the first initialization
 

--- a/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports-env.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/jasperreports-env.sh
@@ -21,6 +21,7 @@ export BITNAMI_DEBUG="${BITNAMI_DEBUG:-false}"
 # By setting an environment variable matching *_FILE to a file path, the prefixed environment
 # variable will be overridden with the value specified in that file
 jasperreports_env_vars=(
+    JASPERREPORTS_ROOT_URL
     JASPERREPORTS_DATA_TO_PERSIST
     JASPERREPORTS_HOST
     JASPERREPORTS_SKIP_BOOTSTRAP
@@ -114,3 +115,5 @@ JASPERREPORTS_DATABASE_PASSWORD="${JASPERREPORTS_DATABASE_PASSWORD:-"${MARIADB_D
 export JASPERREPORTS_DATABASE_PASSWORD="${JASPERREPORTS_DATABASE_PASSWORD:-}" # only used during the first initialization
 
 # Custom environment variables may be defined below
+export JASPERREPORTS_ROOT_URL="${JASPERREPORTS_ROOT_URL:-false}" # only used during the first initialization
+

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libjasperreports.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libjasperreports.sh
@@ -321,7 +321,7 @@ jasperreports_initialize() {
     replace_in_file "$BITNAMI_ROOT_DIR/tomcat/webapps/ROOT/index.jsp" '<%\s*$' '<%\nresponse.sendRedirect("/jasperserver");'
 
     # Move JasperServer to default Tomcat URL
-    if $JASPERREPORTS_ROOT_URL; then 
+    if is_boolean_yes "${JASPERREPORTS_USE_ROOT_URL}"; then 
         rm -rf "$BITNAMI_ROOT_DIR/tomcat/webapps/ROOT"
         rm "$BITNAMI_ROOT_DIR/tomcat/webapps/jasperserver"
         ln -s "$JASPERREPORTS_BASE_DIR" "$BITNAMI_ROOT_DIR/tomcat/webapps/ROOT"

--- a/7/debian-10/rootfs/opt/bitnami/scripts/libjasperreports.sh
+++ b/7/debian-10/rootfs/opt/bitnami/scripts/libjasperreports.sh
@@ -320,6 +320,13 @@ jasperreports_initialize() {
     # Make Tomcat redirect to /jasperserver
     replace_in_file "$BITNAMI_ROOT_DIR/tomcat/webapps/ROOT/index.jsp" '<%\s*$' '<%\nresponse.sendRedirect("/jasperserver");'
 
+    # Move JasperServer to default Tomcat URL
+    if $JASPERREPORTS_ROOT_URL; then 
+        rm -rf "$BITNAMI_ROOT_DIR/tomcat/webapps/ROOT"
+        rm "$BITNAMI_ROOT_DIR/tomcat/webapps/jasperserver"
+        ln -s "$JASPERREPORTS_BASE_DIR" "$BITNAMI_ROOT_DIR/tomcat/webapps/ROOT"
+    fi
+
     # Avoid exit code of previous commands to affect the result of this function
     true
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r57`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r57/7/debian-10/Dockerfile)
+- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r58`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r58/7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/jasperreports GitHub repo](https://github.com/bitnami/bitnami-docker-jasperreports).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r58`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r58/7/debian-10/Dockerfile)
+- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r59`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r59/7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/jasperreports GitHub repo](https://github.com/bitnami/bitnami-docker-jasperreports).
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ To configure JasperReports to send email using SMTP you can set the following en
 - `JASPERREPORTS_SMTP_PASSWORD`: SMTP account password.
 - `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *tls*, *ssl*. No default.
 
+##### Database connection configuration
+
+- `JASPERREPORTS_ROOT_URL`: JasperReports application default URL. Default: **false** at http://example.com/jasperserver. http://example.com/ if **true**.
+
 #### Examples
 
 ##### SMTP configuration using a Gmail account

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r59`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r59/7/debian-10/Dockerfile)
+- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r62`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r59/7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/jasperreports GitHub repo](https://github.com/bitnami/bitnami-docker-jasperreports).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r62`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r59/7/debian-10/Dockerfile)
+- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r62`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r62/7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/jasperreports GitHub repo](https://github.com/bitnami/bitnami-docker-jasperreports).
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ To configure JasperReports to send email using SMTP you can set the following en
 - `JASPERREPORTS_SMTP_PASSWORD`: SMTP account password.
 - `JASPERREPORTS_SMTP_PROTOCOL`: If specified, SMTP protocol to use. Allowed values: *tls*, *ssl*. No default.
 
-##### Database connection configuration
+##### JasperReports base URL configuration
 
 - `JASPERREPORTS_ROOT_URL`: JasperReports application default URL. Default: **false** at http://example.com/jasperserver. http://example.com/ if **true**.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r64`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r64/7/debian-10/Dockerfile)
+- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r67`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r67/7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/jasperreports GitHub repo](https://github.com/bitnami/bitnami-docker-jasperreports).
 
@@ -476,7 +476,7 @@ New versions and releases cadence are not going to be affected. Once a new versi
 - The configuration logic is now based on Bash scripts in the *rootfs/* folder.
 - The container has been migrated to a non-root user approach. Previously the container ran as the `root` user and the Tomcat daemon was started as the `tomcat` user. From now on, both the container and the Tomcat daemon run as user `1001`. As a consequence, the data directory must be writable by that user. You can revert this behavior by changing `USER 1001` to `USER root` in the Dockerfile.
 
-## 7.2.0-debian-10-r64
+## 7.2.0-debian-10-r67
 
 - Java distribution has been migrated from AdoptOpenJDK to OpenJDK Liberica. As part of VMware, we have an agreement with Bell Software to distribute the Liberica distribution of OpenJDK. That way, we can provide support & the latest versions and security releases for Java.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Non-root container images add an extra layer of security and are generally recom
 Learn more about the Bitnami tagging policy and the difference between rolling tags and immutable tags [in our documentation page](https://docs.bitnami.com/tutorials/understand-rolling-tags-containers/).
 
 
-- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r62`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r62/7/debian-10/Dockerfile)
+- [`7`, `7-debian-10`, `7.8.1`, `7.8.1-debian-10-r64`, `latest` (7/debian-10/Dockerfile)](https://github.com/bitnami/bitnami-docker-jasperreports/blob/7.8.1-debian-10-r64/7/debian-10/Dockerfile)
 
 Subscribe to project updates by watching the [bitnami/jasperreports GitHub repo](https://github.com/bitnami/bitnami-docker-jasperreports).
 
@@ -263,7 +263,7 @@ To configure JasperReports to send email using SMTP you can set the following en
 
 ##### JasperReports base URL configuration
 
-- `JASPERREPORTS_ROOT_URL`: JasperReports application default URL. Default: **false** at http://example.com/jasperserver. http://example.com/ if **true**.
+- `JASPERREPORTS_USE_ROOT_URL`: JasperReports application default URL. Default: **false** at http://example.com/jasperserver. http://example.com/ if **true**.
 
 #### Examples
 


### PR DESCRIPTION
**Use case**   

After deployment, bitnami jasperreports container defaults at http://example.com/jasperserver URL. It is a result of either typing the entire url address or being redirected from http://example.com  
However, using jasperreporst API through http://example.com is not possible due to the mentioned redirection made in Tomcat's index.jsp.  

**Change**   

Introduced a new configuration Boolean variable `JASPERREPORTS_ROOT_URL` in jasperreports-env.sh  
By default the variable is set to false with no change in the container behavior.   
Introduced an `If` statement to control jasperreports deployment folder based on `JASPERREPORTS_ROOT_URL` value in libjasperreports.sh
Introduced short description of the option in the README file.

**Benefits**

Enables jasperreport API on plain domain address such as http://example.com/

**Possible drawbacks**

Not known.

**Applicable issues**

#109 